### PR TITLE
Better handling of `docker logs` subprocess call

### DIFF
--- a/src/tests/docker/healthcheck.test.ts
+++ b/src/tests/docker/healthcheck.test.ts
@@ -56,8 +56,14 @@ export default class HealthcheckTest extends Test {
 		this.notice( `Got a ${ chalk.bgWhite.black.bold( response.status ) } response in ${ request.duration }ms` );
 
 		// Get the logs
-		const subprocess = await executeShell( `docker logs ${ this.containerName } --since ${ this.startDate }` );
-		const logs = subprocess.all;
+
+		let logs;
+		try {
+			const subprocess = await executeShell( `docker logs ${ this.containerName } --since ${ this.startDate }` );
+			logs = subprocess.all;
+		} catch ( err ) {
+			this.log( 'Error getting docker logs: ' + ( err as Error ).message );
+		}
 
 		const is200 = response.status === 200;
 

--- a/src/tests/docker/run.test.ts
+++ b/src/tests/docker/run.test.ts
@@ -36,7 +36,7 @@ export default class DockerRun extends Test {
 	async run() {
 		this.notice( `Running Docker image on PORT ${ chalk.yellow( this.port ) } for image ${ chalk.yellow( this.imageTag ) }...` );
 		try {
-			const subprocess = executeShell( `docker run -t --rm --network host --name ${ this.containerName } -e PORT ${ this.imageTag }`, {
+			const subprocess = executeShell( `docker run -t --network host --name ${ this.containerName } -e PORT ${ this.imageTag }`, {
 				...this.envVariables,
 				NODE_VERSION: this.nodeVersion,
 				PORT: this.port,

--- a/src/tests/health/base.test.ts
+++ b/src/tests/health/base.test.ts
@@ -101,8 +101,13 @@ export default abstract class BaseHealthTest extends Test {
 	 */
 	protected async handleRequest( request: TimedResponse ): Promise<Issue> {
 		// Check for logs
-		const subprocess = await executeShell( `docker logs ${ this.containerName } --since ${ request.startDate.toISOString() }` );
-		const logs = subprocess.all;
+		let logs;
+		try {
+			const subprocess = await executeShell( `docker logs ${ this.containerName } --since ${ request.startDate.toISOString() }` );
+			logs = subprocess.all;
+		} catch ( err ) {
+			this.log( 'Error getting docker logs: ' + ( err as Error ).message );
+		}
 
 		if ( request.response.status !== 200 ) {
 			return this.error( `Could not get a ${ chalk.yellow( '200 - OK' ) } response from ${ chalk.bold( request.url ) }.`,


### PR DESCRIPTION
In some scenarios, the `docker logs` command was not working, and Harmonia was not handling that gracefully. 

The `--rm` parameter was removed from the `docker run` command, as it was prone to create errors when fetching the logs in some situations, and there's a clean-up of images and containers either way, later in the Harmonia life-cycle.