### PR TITLE
Add feedback form and "stamp of approval" to the PR markdown report

### DIFF
--- a/src/ci.ts
+++ b/src/ci.ts
@@ -183,7 +183,7 @@ function createMarkdown() {
 
 	let stamp;
 	let initialMessage = `We have tested the application using the commit \`${ options.commit.substring( 0, 7 ) }\` and `;
-	if ( summary.results.Failed || summary.results.aborted ) {
+	if ( summary.results.Failed || summary.results.Aborted ) {
 		// Failed
 		stamp = 'https://cldup.com/GQ-AjSRSzb.png';
 		initialMessage += '__issues were found__ that prevent the application from working. You can review the issues below.';


### PR DESCRIPTION
This PR adds a footer section where it links to the feedback form, to collect feedback directly from the users:

![image](https://user-images.githubusercontent.com/5804923/162999207-d84fd274-d3c1-4c21-8d9e-4ffc15f6d963.png)

Additionally, I have tweaked the report layout to replace the dummy paragraph in the beginning with something more meaningful, including a "stamp" image that gives a stronger visual clue of the test result.

![image](https://user-images.githubusercontent.com/5804923/162999089-b80f84aa-5d1e-4f29-a089-e78c8ed7f1f4.png)

If the test is fully successful (i.e. no warnings or failures), the stamp should be green: 

![image](https://user-images.githubusercontent.com/5804923/163000101-7e4280b4-1865-4d8f-9efc-5d08be1f944e.png)

If there is at least a warning, it will be a yellow stamp:

![image](https://user-images.githubusercontent.com/5804923/163000180-fdfe9808-aa1e-4f9f-932b-bff6694c54aa.png)

Otherwise, if there are any failures or blockers, a red "Failed" stamp will be shown:

![image](https://user-images.githubusercontent.com/5804923/163000325-e537cc9d-42ab-4549-abcc-cf2788929188.png)
