### PR TITLE
Add `engines.node` validation

### DIFF
--- a/src/harmonia.ts
+++ b/src/harmonia.ts
@@ -11,11 +11,11 @@ import Issue from './lib/issue';
 /**
  * Test imports
  */
-import NpmScriptsTest from './tests/npm-scripts.test';
 import TestSuite from './lib/tests/testsuite';
 import DockerSuite from './tests/docker/suite';
 import HealthSuite from './tests/health/suite';
 import TestSuiteResult from './lib/results/testsuiteresult';
+import NPMSuite from './tests/npm/suite';
 
 const log = require( 'debug' )( 'harmonia' );
 
@@ -144,9 +144,7 @@ export default class Harmonia {
 	private setupTests() {
 		log( 'Setting up the tests' );
 		// Register all the necessary tests
-		this.registerTest( new TestSuite( 'Node.JS', 'Test a node.JS site' )
-			.addTest( new NpmScriptsTest() ) );
-
+		this.registerTest( new NPMSuite() );
 		this.registerTest( new DockerSuite() );
 		this.registerTest( new HealthSuite() );
 	}

--- a/src/tests/npm/npm-engines.test.ts
+++ b/src/tests/npm/npm-engines.test.ts
@@ -1,0 +1,36 @@
+import Test from '../../lib/tests/test';
+import chalk from 'chalk';
+import semver from 'semver';
+
+export default class NpmEnginesTest extends Test {
+	private packageJSON;
+	private nodeVersion;
+
+	private npmEnginesDoc = 'https://docs.wpvip.com/technical-references/node-js/managing-node-js-versions/';
+	constructor() {
+		super( 'NPM `package.json` engine', 'Checks if the `engine` propriety is set and a valid version' );
+	}
+
+	prepare() {
+		this.packageJSON = this.getSiteOption( 'packageJSON' );
+		this.nodeVersion = this.getSiteOption( 'nodejsVersion' );
+	}
+
+	async run() {
+		const engines = this.packageJSON.engines;
+
+		if ( ! engines ) {
+			// Engine is not set, all good.
+			return;
+		}
+
+		if ( engines.node ) {
+			const nodeSemVer = semver.coerce( this.nodeVersion ).version;
+			if ( ! semver.satisfies( nodeSemVer, engines.node ) ) {
+				this.blocker( `The ${ chalk.italic( 'engine.node' ) } version in your ${ chalk.bold( 'package.json' ) } ` +
+					`(${ chalk.yellow( engines.node ) }) does not satisfies the production Node.js version (${ chalk.yellow( nodeSemVer ) })`,
+				this.npmEnginesDoc );
+			}
+		}
+	}
+}

--- a/src/tests/npm/npm-scripts.test.ts
+++ b/src/tests/npm/npm-scripts.test.ts
@@ -1,4 +1,4 @@
-import Test from '../lib/tests/test';
+import Test from '../../lib/tests/test';
 import chalk from 'chalk';
 
 export default class NpmScriptsTest extends Test {

--- a/src/tests/npm/package-validation.test.ts
+++ b/src/tests/npm/package-validation.test.ts
@@ -1,4 +1,4 @@
-import Test from '../lib/tests/test';
+import Test from '../../lib/tests/test';
 import chalk from 'chalk';
 
 export default class PackageValidationTest extends Test {

--- a/src/tests/npm/suite.ts
+++ b/src/tests/npm/suite.ts
@@ -1,0 +1,14 @@
+import TestSuite from '../../lib/tests/testsuite';
+import NpmScriptsTest from './npm-scripts.test';
+import NpmEnginesTest from './npm-engines.test';
+
+export default class NPMSuite extends TestSuite {
+	constructor() {
+		super( 'NPM package.json', 'Checks for valid `package.json` configuration' );
+	}
+
+	setupTests() {
+		this.addTest( new NpmScriptsTest() )
+			.addTest( new NpmEnginesTest() );
+	}
+}


### PR DESCRIPTION
If there is an engines property set in package.json, check to make sure that it matches the current major version of Node.js for that site. Fail if it doesn’t.

There is also a slight change on the tests structure: there is a new **NPMSuite test suite**, which includes both the new `engines` check and the existing `NpmScriptsTest`, and it's defined under `/src/tests/npm/suite.ts`.

