### PR TITLE
Send available environment variables to `docker run` command.

### DIFF
--- a/src/tests/docker/run.test.ts
+++ b/src/tests/docker/run.test.ts
@@ -45,7 +45,7 @@ export default class DockerRun extends Test {
 
 			// Build the `--env` string of options for Docker with the environment variable keys
 			const environmentVarDockerOption = Object.keys( environmentVars ).reduce( ( string, envVarName ) => {
-				return string + ` -e ${ envVarName }`;
+				return `${ string } -e ${ envVarName }`;
 			}, '' );
 
 			const subprocess = executeShell( `docker run -t --network host --name ${ this.containerName } ${ environmentVarDockerOption } ${ this.imageTag }`,


### PR DESCRIPTION
The `docker run` command was only using a single environment variable - `PORT`, as it was the only being passed in the `docker run` argument (`-e PORT`).

This change builds a string with `-e` arguments for all the exposed environment variables. The `.env` file is now also used to populate the runtime environment variables.

The verbose validation was also moved a bit earlier, before the `waait` call, so it can output the `npm start` output. 