### PR TITLE
Allow Node.JS version 18 to be used in Harmonia testing environment

### DIFF
--- a/src/lib/configs/site.config.ts
+++ b/src/lib/configs/site.config.ts
@@ -15,7 +15,7 @@ export interface SiteConfigArgs {
 	dataOnlyImage?: string,
 }
 
-export const ALLOWED_NODEJS_VERSIONS = [ 12, 14, 16, 18 ];
+export const ALLOWED_NODEJS_VERSIONS = [ 14, 16, 18 ];
 
 export default class SiteConfig extends BaseConfig<any> {
 	constructor( args: SiteConfigArgs ) {


### PR DESCRIPTION
Add Node.js major version 18 to the allowed list of Node.js versions (`ALLOWED_NODEJS_VERSIONS`).