### PR TITLE
Fix `fetchWithTiming` calculation of the duration

### DIFF
--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -54,7 +54,8 @@ export default async function fetchWithTiming( url, options? ): Promise<TimedRes
 	}
 
 	// Divide by a million to get from ns to ms
-	const elaspedTime = process.hrtime( startTime )[ 1 ] / 1000000;
+	const endTime = process.hrtime( startTime );
+	const elaspedTime = endTime[ 0 ] * 1000 + endTime[ 1 ] / 1000000;
 
 	return {
 		url: url,


### PR DESCRIPTION
`process.hrtime` returns two values: `[ seconds, nanoseconds]`. The total amount of time for a request can be retrieved by adding the seconds to the nanoseconds, and in our case, converting everything to miliseconds: ` endTimeInSeconds * 1000 + endTimeInNanoseconds / 1000000`

