### PR TITLE
Include a `?` to the `/cache-healthcheck` request

### DIFF
--- a/src/tests/health/static-requests.test.ts
+++ b/src/tests/health/static-requests.test.ts
@@ -3,7 +3,7 @@ import BaseHealthTest from './base.test';
 export default class StaticRequestsTest extends BaseHealthTest {
 	protected paths = [
 		'/',
-		'/cache-healthcheck',
+		'/cache-healthcheck?',
 	]
 
 	constructor() {


### PR DESCRIPTION
Health-check endpoint requires a question-mark (`/cache-healthcheck?`). 