### PR TITLE
PR Comment: Remove stamp image from the comment header

### DIFF
--- a/src/ci.ts
+++ b/src/ci.ts
@@ -178,24 +178,22 @@ function createMarkdown() {
 	// Add result summary
 	const summary = results.summary;
 
-	let stamp;
+	let resultString;
 	if ( summary.results.Failed || summary.results.Aborted ) {
 		// Failed
-		stamp = 'https://cldup.com/GQ-AjSRSzb.png';
+		resultString = 'have failed';
 	} else if ( summary.results.PartialSuccess ) {
 		// Partial Success
-		stamp = 'https://cldup.com/bL0eXSSJyF.png';
+		resultString = 'passed with warnings';
 	} else if ( summary.results.Success ) {
 		// Success
-		stamp = 'https://cldup.com/WhvxXikKLB.png';
+		resultString = 'passed';
 	}
 
 	let prettyResult: string;
 
 	// Convert json to markup/html
-	prettyResult = `<img align="right" width="200" src="${ stamp }">\n\n`;
-
-	prettyResult += `## Test summary for commit \`${ options.commit.substring( 0, 7 ) }\`\n\n`;
+	prettyResult = `## Tests for commit \`${ options.commit.substring( 0, 7 ) }\` ${ resultString }\n\n`;
 
 	if ( summary.results.Success ) {
 		prettyResult += ':white_check_mark: &nbsp;&nbsp;';


### PR DESCRIPTION
Remove the stamp image with PASS/FAILED and add the test result (Pass, Pass with warnings, or Failed) to the comment title.

# Before

<img align="right" width="200" src="https://cldup.com/bL0eXSSJyF.png">

## Test summary for commit `abcd012`

:white_check_mark: &nbsp;&nbsp;🟩🟩🟩🟩🟩🟩🟩 7 tests
:warning: &nbsp;&nbsp;🟨🟨 2 tests

(...) 

---

# After

## Tests for commit `abcd012` passed with warnings

:white_check_mark: &nbsp;&nbsp;🟩🟩🟩🟩🟩🟩🟩 7 tests
:warning: &nbsp;&nbsp;🟨🟨 2 tests

(...)