### PR TITLE
Change health-check failed request from Blocker to Error

### DIFF
--- a/src/tests/health/base.test.ts
+++ b/src/tests/health/base.test.ts
@@ -57,7 +57,7 @@ export default abstract class BaseHealthTest extends Test {
 					`--until ${ error.getEndDate().toISOString() }` );
 				const logs = subprocess.all;
 
-				this.blocker( `Error fetching ${ error.getURL() }: ${ error.message }`, undefined, { all: logs } );
+				this.error( `Error fetching ${ error.getURL() }: ${ error.message }`, undefined, { all: logs } );
 			}
 			console.log( error );
 		}


### PR DESCRIPTION
Change the severity of the issue when one of the Health Check request fails ( `fetch` exception ). 
This PR changes from Blocker to Error. 