### PR TITLE
Add line linking to public docs on the GitHub feedback markdown

### DIFF
--- a/src/ci.ts
+++ b/src/ci.ts
@@ -258,7 +258,11 @@ function createMarkdown() {
 			`viewform?usp=pp_url&entry.1524908984=${ pullRequestURL }`;
 
 		prettyResult += '\n  :arrow_right:  __This tool is under active development__. If you have any feedback, ' +
-			`you are invited to [fill this very short form](${ feedbackLink }).`;
+			`you are invited to [fill this very short form](${ feedbackLink }).\n`;
+
+		prettyResult += '\n  :question:  __Want to learn more?__ Take a look at the [documentation page]' +
+			'(https://docs.wpvip.com/technical-references/nodejs-deployment-validation/) for more information about ' +
+			'these tests and the automatic testing process.';
 	}
 
 	return prettyResult;


### PR DESCRIPTION
Adds a new line to the footer of the test results, including a link to the public documentation.

Example:

![image](https://user-images.githubusercontent.com/5804923/176928795-95fb585c-c7d7-4437-96a2-7fd61ab701d6.png)
