### PR TITLE
CLI: Fix issue when printing output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,7 @@ function logToConsole( ...messages: string[] ) {
 		return;
 	}
 
-	messages.forEach( console.log );
+	messages.forEach( message => console.log( message ) );
 }
 
 const randomPort = Math.floor( Math.random() * 1000 ) + 3001; // Get a PORT from 3001 and 3999


### PR DESCRIPTION
When outputting a string to the console, it was also outputting the array index and the array itself, given that `forEach` callback has three arguments.

![image](https://user-images.githubusercontent.com/5804923/186409787-599d5ebd-731e-4dd8-895b-7491225a47bf.png)

This change addresses this issue by only calling `console.log` with the first argument, the message itself. 