### PR TITLE
Add Polyfill for `AbortController` for Node.js <= 14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "execa": "^5.1.1",
         "get-urls": "^10.0.1",
         "github-api": "^3.4.0",
+        "node-abort-controller": "^3.0.1",
         "node-fetch": "^2.6.7",
         "semver": "^7.3.5",
         "strip-ansi": "^6.0.1",
@@ -7481,6 +7482,11 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/node-abort-controller": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
+      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -15375,6 +15381,11 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
+    },
+    "node-abort-controller": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
+      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw=="
     },
     "node-fetch": {
       "version": "2.6.7",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "execa": "^5.1.1",
     "get-urls": "^10.0.1",
     "github-api": "^3.4.0",
+    "node-abort-controller": "^3.0.1",
     "node-fetch": "^2.6.7",
     "semver": "^7.3.5",
     "strip-ansi": "^6.0.1",

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,5 +1,6 @@
 import fetch, { FetchError, Response } from 'node-fetch';
 import { HarmoniaError } from '../lib/errors';
+import { AbortController } from 'node-abort-controller';
 
 export interface TimedResponse {
 	url: string;


### PR DESCRIPTION
`AbortController` was introduced with Node 15, so when running Harmonia on an environment with an older Node.js version, such as 14, it would fail the tests with a `not defined` error.

```
  [ Health check ] - Validates dynamic `PORT` environment variable and `/cache-healthcheck?` implementation
    Notice      Sending a GET request to http://localhost:3432/cache-healthcheck?... 
    Blocker     Error fetching http://localhost:3432/cache-healthcheck?: AbortController is not defined 
  Test aborted! - There was a critical error that makes
the application fully incompatible with VIP Go.
```

This PR adds a Polyfill package that should take care of that missing controller, making it possible to run on Node 14 or older. 