### PR TITLE
NPM/NPX: Add new `bin` entry for npm v7 or older

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Provide a set of automated tests (or checks) that can test and validate the application functionality and responsiveness with an environment as close to production as possible, before the actual deployment to an environment.",
   "main": "dist/index.js",
   "bin": {
+    "aaa-npm-npx-pre-v7-use-me": "dist/preflight-checks.js",
     "vip-go-preflight-checks": "dist/preflight-checks.js",
     "harmonia": "dist/cli.js",
     "harmonia-ci": "dist/ci.js"


### PR DESCRIPTION
[A bug with npxlib loads the first binary from an alphabetically sorted list](https://github.com/npm/npx/issues/82). This makes `npx` load the wrong binary (`harmonia` instead of `vip-go-preflight-checks`) on Node 14/npm 6, for example. 

This PR adds a new duplicate binary, `aaa-npm-npx-pre-v7-use-me` to force `npx` to use it when using a version of `npm` older or equal to 7. 