### PR TITLE
Forward Docker ports instead of using `host` network

### DIFF
--- a/src/tests/docker/run.test.ts
+++ b/src/tests/docker/run.test.ts
@@ -49,7 +49,7 @@ export default class DockerRun extends Test {
 				return `${ string } -e ${ envVarName }`;
 			}, '' );
 
-			const subprocess = executeShell( `docker run -t --network host --name ${ this.containerName } ${ environmentVarDockerOption } ${ this.imageTag }`,
+			const subprocess = executeShell( `docker run -t --name ${ this.containerName } -p ${ this.port }:${ this.port } ${ environmentVarDockerOption } ${ this.imageTag }`,
 				environmentVars );
 
 			if ( Harmonia.isVerbose() ) {


### PR DESCRIPTION
The `host` network is only supported on Linux machines. Instead of using this network adapter, do the proper port forwarding of the service port using `-p 1234:1234`.

This solves networking issues on Mac and Windows users.

After this PR is merged, we need to validate if the functionality in Teamcity is affected. I remember that we ended up using `host` as a way to go around the container running inside a container scenario that happens on CI environments. 