### PR TITLE
Implements configurable `wait` time

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -221,6 +221,7 @@ const siteOptions = new SiteConfig( {
 	repository: 'wpcom/test',
 	baseURL: 'http://localhost:' + options.port,
 	topRequests: testURLs,
+	wait: options.wait ?? 3000,
 } );
 
 // Get package.json

--- a/src/lib/configs/site.config.ts
+++ b/src/lib/configs/site.config.ts
@@ -9,6 +9,7 @@ export interface SiteConfigArgs {
 	packageJson?: object,
 	dotenv?: object,
 	topRequests?: string[],
+	wait?: number,
 	// Docker specific arguments
 	dockerBuildEnvs?: string,
 	dockerImage?: string,
@@ -21,6 +22,11 @@ export default class SiteConfig extends BaseConfig<any> {
 	constructor( args: SiteConfigArgs ) {
 		super();
 		this.merge( args );
+
+		// Set default wait time of 3000ms
+		if ( ! args.wait ) {
+			this.set( 'wait', 3000 );
+		}
 	}
 
 	protected validate(): boolean {

--- a/src/tests/docker/run.test.ts
+++ b/src/tests/docker/run.test.ts
@@ -10,6 +10,7 @@ export default class DockerRun extends Test {
 	private envVariables = {};
 	private imageTag = '';
 	private port = 0;
+	private wait = 3000;
 	private containerName = '';
 
 	constructor() {
@@ -21,6 +22,7 @@ export default class DockerRun extends Test {
 		this.nodeVersion = this.getSiteOption( 'nodejsVersion' );
 		this.envVariables = this.getEnvironmentVariables();
 		this.port = this.getEnvVar( 'PORT' ) as number;
+		this.wait = this.getSiteOption( 'wait' );
 
 		// Get the docker image tag
 		if ( ! this.get( 'dockerImage' ) ) {
@@ -56,7 +58,8 @@ export default class DockerRun extends Test {
 				subprocess.stdout?.pipe( process.stdout );
 			}
 
-			await wait( 3000 ); // Wait a little, giving time for the server to boot up
+			this.notice( `Waiting ${ chalk.yellow( this.wait + 'ms' ) } for the container to start...` );
+			await wait( this.wait ); // Wait a little, giving time for the server to boot up
 
 			// If subprocess has an exit code, it means that it exited prematurely.
 			// By awaiting the subprocess, we force it to resolve and handle the error in the catch block


### PR DESCRIPTION
Although the `--wait` option is available, the wait time was hardcoded to 3000ms. This PR adds the option to configure the wait time to any value, to be changed if needed. 