### PR TITLE
Update NPM publishing workflows

### DIFF
--- a/.github/workflows/npm-prepare-release.yml
+++ b/.github/workflows/npm-prepare-release.yml
@@ -1,0 +1,29 @@
+---
+name: Prepare new npm release
+
+on:
+  workflow_dispatch:
+    inputs:
+      npm-version-type:
+        description: 'The npm version type we are publishing.'
+        required: true
+        type: choice
+        default: 'patch'
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  prepare:
+    name: Prepare a new npm release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@v3
+
+      - name: Run npm-prepare-release
+        uses: Automattic/vip-actions/npm-prepare-release@v0.1.2
+        with:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          npm-version-type: ${{ inputs.npm-version-type }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,24 +1,16 @@
-name: npm publish
+name: Publish to npm (if applicable)
+
 on:
-  workflow_dispatch:
-    inputs:
-      # This is copied from npm-publish/action.yml
-      npm-version-type:
-        description: 'The npm version type we are publishing.'
-        required: true
-        type: choice
-        default: 'patch'
-        options:
-          - patch
-          - minor
-          - major
+  pull_request:
+    types: [closed]
 
 jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    if: contains( github.event.pull_request.labels.*.name, '[ Type ] NPM version update' ) && startsWith( github.head_ref, 'release/') && github.event.pull_request.merged == true
     steps:
-      - uses: Automattic/vip-actions/npm-publish@v0.1.1
+      - uses: Automattic/vip-actions/npm-publish@v0.1.2
         with:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          npm-version-type: ${{ inputs.npm-version-type }}


### PR DESCRIPTION
## Description

Apply updates making the NPM publishing actions compatible with https://github.com/Automattic/vip-actions/pull/27. Splits the current `npm-publish` action into two actions: `npm-prepare-release` and `npm-publish`.
