### PR TITLE
ci: update workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,23 +18,18 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version:
-          - 16
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v4
         with:
           cache: 'npm'
-          node-version: ${{ matrix.node-version }}
+          node-version: lts/*
 
       - name: Install
-        run: npm install
+        run: npm ci
 
       - name: Check types
         run: npm run check-types

--- a/.github/workflows/npm-prepare-release.yml
+++ b/.github/workflows/npm-prepare-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run npm-prepare-release
         uses: Automattic/vip-actions/npm-prepare-release@v0.1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,19 +23,20 @@ jobs:
         node-version:
           - 16
           - 18
+          - 20
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v4
         with:
           cache: 'npm'
           node-version: ${{ matrix.node-version }}
 
       - name: Install
-        run: npm install
+        run: npm ci
 
       - name: Test
         run: npm run test:unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           - 16
           - 18
           - 20
+          - 22
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR:
  * Adds Node.js 20 and 22 to the "Test" workflow (to match #82);
  * Updates `actions/checkout` and `actions/setup-node` to the latest versions;
  * Makes the "Lint" workflow run on the LTS Node.js;
  * Forces `npm ci` instead of `npm install`.