### PR TITLE
ci: add Dependency Review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,33 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    name: Review Dependencies
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.deps.dev:443
+            api.github.com:443
+            api.securityscorecards.dev:443
+            github.com:443
+
+      - name: Check out the source code
+        uses: actions/checkout@v4.1.2
+
+      - name: Review dependencies
+        uses: actions/dependency-review-action@v4.5.0
+        with:
+          comment-summary-in-pr: true
+          show-openssf-scorecard: true
+          vulnerability-check: true


### PR DESCRIPTION
This PR adds a workflow to review dependencies with GitHub's Dependency Review Action.
