### PR TITLE
fix: code scanning alerts for GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:

--- a/.github/workflows/npm-prepare-release.yml
+++ b/.github/workflows/npm-prepare-release.yml
@@ -14,16 +14,22 @@ on:
           - minor
           - major
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     name: Prepare a new npm release
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out the source code
         uses: actions/checkout@v3
 
       - name: Run npm-prepare-release
-        uses: Automattic/vip-actions/npm-prepare-release@v0.1.2
+        uses: Automattic/vip-actions/npm-prepare-release@1137b91acf0f5ea4e0db044bcf14ceabed9b068f # trunk
         with:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           npm-version-type: ${{ inputs.npm-version-type }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,13 +4,21 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
     if: contains( github.event.pull_request.labels.*.name, '[ Type ] NPM version update' ) && startsWith( github.head_ref, 'release/') && github.event.pull_request.merged == true
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
     steps:
-      - uses: Automattic/vip-actions/npm-publish@v0.1.2
+      - uses: Automattic/vip-actions/npm-publish@1137b91acf0f5ea4e0db044bcf14ceabed9b068f # trunk
         with:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PROVENANCE: 'true'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     name: Stale
@@ -12,4 +15,4 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: Automattic/vip-actions/stale@trunk
+      - uses: Automattic/vip-actions/stale@1137b91acf0f5ea4e0db044bcf14ceabed9b068f # trunk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:


### PR DESCRIPTION
* [x] [CSA-1](https://github.com/Automattic/vip-go-harmonia/security/code-scanning/1): Workflow does not contain permissions (`npm-publish`)
* [x] [CSA-2](https://github.com/Automattic/vip-go-harmonia/security/code-scanning/2): Workflow does not contain permissions (`lint`)
* [x] [CSA-3](https://github.com/Automattic/vip-go-harmonia/security/code-scanning/3): Workflow does not contain permissions (`npm-prepare-release`)
* [x] [CSA-4](https://github.com/Automattic/vip-go-harmonia/security/code-scanning/4): Workflow does not contain permissions (`test`)
* [x] [CSA-5](https://github.com/Automattic/vip-go-harmonia/security/code-scanning/5): Unpinned tag for a non-immutable Action in workflow (`npm-publish`, `Automattic/vip-actions/npm-publish@v0.1.2`)
* [x] [CSA-6](https://github.com/Automattic/vip-go-harmonia/security/code-scanning/6): Unpinned tag for a non-immutable Action in workflow (`npm-prepare-release`, `Automattic/vip-actions/npm-prepare-release@v0.1.2`)
* [x] [CSA-7](https://github.com/Automattic/vip-go-harmonia/security/code-scanning/5): Unpinned tag for a non-immutable Action in workflow (`stale`, `Automattic/vip-actions/stale@trunk`)
