### PR TITLE
fix: escape shell arguments

### DIFF
--- a/src/tests/docker/build.test.ts
+++ b/src/tests/docker/build.test.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import Test from '../../lib/tests/test';
 import chalk from 'chalk';
-import { executeShell, executeShellSync } from '../../utils/shell';
+import { escapeShellArg, executeShell, executeShellSync } from '../../utils/shell';
 import Harmonia from '../../harmonia';
 
 export default class DockerBuild extends Test {
@@ -70,7 +70,7 @@ export default class DockerBuild extends Test {
 	 */
 	private async buildApp(): Promise<string> {
 		const script = path.resolve( __dirname, '../../..', 'scripts/build-app/build.sh' );
-		const subprocess = executeShell( `bash ${ script }`, {
+		const subprocess = executeShell( `bash ${ escapeShellArg( script ) }`, {
 			...this.envVariables,
 			NODE_VERSION: this.nodeVersion,
 		} );
@@ -97,7 +97,7 @@ export default class DockerBuild extends Test {
 		this.notice( `Using a data-only image ${ chalk.yellow( dataImage ) } ` );
 
 		const script = path.resolve( __dirname, '../../..', 'scripts/data-only/build.sh' );
-		const subprocess = executeShell( `bash ${ script }`, {
+		const subprocess = executeShell( `bash ${ escapeShellArg( script ) }`, {
 			NODE_VERSION: this.nodeVersion,
 			DATAONLY_IMAGE: dataImage,
 		} );
@@ -123,7 +123,7 @@ export default class DockerBuild extends Test {
 	 */
 	private getDockerImage( dockerImage: string ): string | boolean {
 		try {
-			const subprocess = executeShellSync( `docker images --filter reference=${ dockerImage } --format {{.Repository}}:{{.Tag}}` );
+			const subprocess = executeShellSync( `docker images --filter reference=${ escapeShellArg( dockerImage ) } --format {{.Repository}}:{{.Tag}}` );
 
 			if ( subprocess.stdout === '' || subprocess.exitCode !== 0 ) {
 				return false;

--- a/src/tests/docker/healthcheck.test.ts
+++ b/src/tests/docker/healthcheck.test.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 
 import Test from '../../lib/tests/test';
-import { executeShell } from '../../utils/shell';
+import { escapeShellArg, executeShell } from '../../utils/shell';
 import fetchWithTiming, { HarmoniaFetchError } from '../../utils/http';
 
 const CACHE_HEALTHCHECK_ROUTE = '/cache-healthcheck?';
@@ -57,7 +57,7 @@ export default class HealthcheckTest extends Test {
 
 		let logs;
 		try {
-			const subprocess = await executeShell( `docker logs ${ this.containerName } --since ${ this.startDate }` );
+			const subprocess = await executeShell( `docker logs ${ escapeShellArg( this.containerName ) } --since ${ escapeShellArg( this.startDate ) }` );
 			logs = subprocess.all;
 		} catch ( err ) {
 			this.log( 'Error getting docker logs: ' + ( err as Error ).message );

--- a/src/tests/docker/run.test.ts
+++ b/src/tests/docker/run.test.ts
@@ -1,6 +1,6 @@
 import Test from '../../lib/tests/test';
 import chalk from 'chalk';
-import { executeShell } from '../../utils/shell';
+import { escapeShellArg, executeShell } from '../../utils/shell';
 import { createHash } from 'crypto';
 import { wait } from '../../utils/wait';
 import Harmonia from '../../harmonia';
@@ -51,7 +51,7 @@ export default class DockerRun extends Test {
 
 			// Build the `--env` string of options for Docker with the environment variable keys
 			const environmentVarDockerOption = Object.keys( environmentVars ).reduce( ( string, envVarName ) => {
-				return `${ string } -e ${ envVarName }`;
+				return `${ string } -e ${ escapeShellArg( envVarName ) }`;
 			}, '' );
 
 			let dockerNetwork = `-p ${ this.port }:${ this.port }`;
@@ -60,8 +60,8 @@ export default class DockerRun extends Test {
 				dockerNetwork = '--network host';
 			}
 
-			const dockerCommand = `docker run -t ${ dockerNetwork } --name ${ this.containerName } ${ environmentVarDockerOption } ${ this.imageTag }`;
-			const subprocess = executeShell( dockerCommand,	environmentVars );
+			const dockerCommand = `docker run -t ${ dockerNetwork } --name ${ escapeShellArg( this.containerName ) } ${ environmentVarDockerOption } ${ escapeShellArg( this.imageTag ) }`;
+			const subprocess = executeShell( dockerCommand, environmentVars );
 
 			if ( Harmonia.isVerbose() ) {
 				subprocess.stdout?.pipe( process.stdout );

--- a/src/tests/health/base.test.ts
+++ b/src/tests/health/base.test.ts
@@ -50,7 +50,7 @@ export default abstract class BaseHealthTest extends Test {
 			if ( error instanceof HarmoniaFetchError ) {
 				// Get logs
 				const subprocess = await executeShell( `docker logs ${ escapeShellArg( this.containerName ) } --since ${ escapeShellArg( error.getStartDate().toISOString() ) } ` +
-					`--until ${ error.getEndDate().toISOString() }` );
+					`--until ${ escapeShellArg( error.getEndDate().toISOString() ) }` );
 				const logs = subprocess.all;
 
 				this.error( `Error fetching ${ error.getURL() }: ${ error.message }`, undefined, { all: logs } );

--- a/src/tests/health/base.test.ts
+++ b/src/tests/health/base.test.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 
 import Test from '../../lib/tests/test';
-import { executeShell } from '../../utils/shell';
+import { escapeShellArg, executeShell } from '../../utils/shell';
 import fetchWithTiming, { HarmoniaFetchError, TimedResponse } from '../../utils/http';
 import Issue from '../../lib/issue';
 import { isWebUri } from '../../utils/url';
@@ -49,7 +49,7 @@ export default abstract class BaseHealthTest extends Test {
 		} catch ( error ) {
 			if ( error instanceof HarmoniaFetchError ) {
 				// Get logs
-				const subprocess = await executeShell( `docker logs ${ this.containerName } --since ${ error.getStartDate().toISOString() } ` +
+				const subprocess = await executeShell( `docker logs ${ escapeShellArg( this.containerName ) } --since ${ escapeShellArg( error.getStartDate().toISOString() ) } ` +
 					`--until ${ error.getEndDate().toISOString() }` );
 				const logs = subprocess.all;
 
@@ -93,7 +93,7 @@ export default abstract class BaseHealthTest extends Test {
 		// Check for logs
 		let logs;
 		try {
-			const subprocess = await executeShell( `docker logs ${ this.containerName } --since ${ request.startDate.toISOString() }` );
+			const subprocess = await executeShell( `docker logs ${ escapeShellArg( this.containerName ) } --since ${ escapeShellArg( request.startDate.toISOString() ) }` );
 			logs = subprocess.all;
 		} catch ( err ) {
 			this.log( 'Error getting docker logs: ' + ( err as Error ).message );

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -1,9 +1,30 @@
-import execa, { ExecaChildProcess } from 'execa';
+import { platform } from 'node:os';
+import execa, { type ExecaChildProcess } from 'execa';
 
 const subprocesses: ExecaChildProcess[] = [];
 let cwd = process.cwd();
 
-export function executeShell( command, envVars = {} ) {
+export function escapeShellArg( arg: string ): string {
+	if ( ! arg ) {
+		return '""';
+	}
+
+	if ( platform() === 'win32' ) {
+		// For Windows cmd.exe, we need to handle several special characters
+		// First handle backslashes and double quotes
+		let escaped = arg.replace( /(\\*)"/g, '$1$1\\"' ).replace( /(\\*)$/, '$1$1' );
+
+		// Then handle special shell characters: ^ ! % ~ & < > | ' `
+		escaped = escaped.replace( /([&^|<>()!"%~])/g, '^$1' );
+
+		return `"${ escaped }"`;
+	}
+
+	// Unix/Linux/macOS: single quotes around the string and escape single quotes within
+	return `'${ arg.replace( /'/g, "'\\''" ) }'`;
+}
+
+export function executeShell( command: string, envVars = {} ) {
 	const envVariables = {
 		VIP_GO_APP_ID: 'unknown',
 	};
@@ -11,7 +32,7 @@ export function executeShell( command, envVars = {} ) {
 	const promise = execa.command( command, {
 		all: true,
 		cwd,
-		env: Object.assign( {}, envVariables, envVars ),
+		env: { ...envVariables, ...envVars },
 	} );
 
 	subprocesses.push( promise );
@@ -32,7 +53,7 @@ export function executeShell( command, envVars = {} ) {
 	return promise;
 }
 
-export function executeShellSync( command, envVars = {} ) {
+export function executeShellSync( command: string, envVars = {} ) {
 	const envVariables = {
 		VIP_GO_APP_ID: 'unknown',
 	};
@@ -40,7 +61,7 @@ export function executeShellSync( command, envVars = {} ) {
 	return execa.commandSync( command, {
 		all: true,
 		cwd,
-		env: Object.assign( {}, envVariables, envVars ),
+		env: { ...envVariables, ...envVars },
 	} );
 }
 


### PR DESCRIPTION
This PR introduces the `escapeShellArg()` function and uses it to escape potentially unsafe arguments passed to `executeShell()` and `executeShellSync()`.

Related: PLTFRM-593
Related: https://github.com/Automattic/vip-go-harmonia/security/code-scanning/8
