### PR TITLE
fix: properly replace newlines in messages

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -430,7 +430,7 @@ harmonia.on( 'issue', ( issue: Issue ) => {
 	const documentation = issue.documentation ? `(${ issue.documentation })` : '';
 
 	// Replace \n with \n\t\t to keep new lines aligned
-	const message = issue.message.replace( '\n', '\n\t\t' );
+	const message = issue.message.replace( /\n/g, '\n\t\t' );
 	logToConsole( `    ${ issueTypeString } \t${ message } ${ documentation }` );
 
 	// If it's a Blocker or Error, and the issue includes a stdout, print it out.


### PR DESCRIPTION
See: https://github.com/Automattic/vip-go-harmonia/security/code-scanning/9

Related: PLTFRM-594